### PR TITLE
Firmadigital

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Estas son algunas de sus características:
 - Extras de terceros preinstalados, como tipografías Arial, Times New Roman, etc., plugins Oracle Java, Adobe Flash, o codecs multimedia.
 - Software adicional como Gimp, Google Chrome, Spotify o la herramienta de configuración de AURI y Eduroam.
 - Actualizaciones automáticas del sistema operativo y de todos los programas instalados. Estas son silenciosas y no requieren intervención del usuario.
-
+- Soporte para lectores de firma digital, certificados de la CA nacional y programas instalados del BCCR.
 
 ## Capturas de pantalla
 

--- a/ubuntu-16.04-ucr-config.sh
+++ b/ubuntu-16.04-ucr-config.sh
@@ -410,10 +410,10 @@ sudo sed -i \
 
 if [ "$arch" == 'x86' ]
 then
-  wget -o firmador-bccr.deb https://www.firmadigital.go.cr/Bccr.Firma.Fva.InstaladoresMultiplataforma/Linux/x86/firmador-bccr_3.0_i386.deb
+  wget -O firmador-bccr.deb https://www.firmadigital.go.cr/Bccr.Firma.Fva.InstaladoresMultiplataforma/Linux/x86/firmador-bccr_3.0_i386.deb
 else
-  wget -o firmador-bccr.deb  https://www.firmadigital.go.cr/Bccr.Firma.Fva.InstaladoresMultiplataforma/Linux/x64/firmador-bccr_3.0_amd64.deb
+  wget -O firmador-bccr.deb  https://www.firmadigital.go.cr/Bccr.Firma.Fva.InstaladoresMultiplataforma/Linux/x64/firmador-bccr_3.0_amd64.deb
 fi
 
 sudo dpkg -i firmador-bccr.deb
-sudo apt-get install -f 
+rm firmador-bccr.deb

--- a/ubuntu-16.04-ucr-config.sh
+++ b/ubuntu-16.04-ucr-config.sh
@@ -110,6 +110,12 @@ sudo sed -i \
 
 packages="$packages libreoffice libreoffice-l10n-en-za libreoffice-l10n-en-gb libreoffice-help-en-gb libreoffice-style-sifr"
 
+# Firma digital 
+
+sudo bash -c 'wget -O - http://repos.solvosoft.com/firmadigitalcr.gpg.key | apt-key add -'
+sudo sh -c 'echo "deb http://repos.solvosoft.com/ubuntu xenial main" > /etc/apt/sources.list.d/repos-firmadigital.list'
+packages="$packages firmadigitalcr"
+
 # Google Chrome o Chromium
 #
 # Para sistemas de 64bits se anade el repositorio de Google Chrome. Este no
@@ -399,3 +405,15 @@ sudo sed -i \
 -e 's/^#force_color_prompt=yes/force_color_prompt=yes/' \
 /etc/skel/.bashrc
 
+# Firmador BCCR
+
+
+if [ "$arch" == 'x86' ]
+then
+  wget -o firmador-bccr.deb https://www.firmadigital.go.cr/Bccr.Firma.Fva.InstaladoresMultiplataforma/Linux/x86/firmador-bccr_3.0_i386.deb
+else
+  wget -o firmador-bccr.deb  https://www.firmadigital.go.cr/Bccr.Firma.Fva.InstaladoresMultiplataforma/Linux/x64/firmador-bccr_3.0_amd64.deb
+fi
+
+sudo dpkg -i firmador-bccr.deb
+sudo apt-get install -f 


### PR DESCRIPTION
Este PR agrega los certificados digitales de la CA nacional, así como el paquete firmadigitalcr y el cliente de firma digital del BCCR.
**firmadigitalcr**  contiene todos los parches conocidos hasta el momento para hacer funcional firma digital en Linux.
