### PR TITLE
Corregir nombre para corrector gramatical

### DIFF
--- a/ubuntu-16.04-ucr-config.sh
+++ b/ubuntu-16.04-ucr-config.sh
@@ -428,9 +428,11 @@ Keywords=Network;Wireless;Wi-Fi;Wifi;LAN;AURI;Eduroam;Internet;Red" > /usr/share
 sudo timedatectl set-timezone America/Costa_Rica
 
 # Complementos para LibreOffice
-wget https://www.languagetool.org/download/LanguageTool-stable.oxt
-sudo unopkg add LanguageTool-stable.oxt
-rm LanguageTool-stable.oxt
+# LanguageTool.oxt (corrector gramatical)
+# ultima version en https://www.languagetool.org/download/
+wget https://www.languagetool.org/download/LanguageTool-3.9.oxt
+sudo unopkg add LanguageTool-3.9.oxt
+rm LanguageTool-3.9.oxt
 
 # Firmador BCCR
 if [ "$arch" == 'x86' ]

--- a/ubuntu-16.04-ucr-config.sh
+++ b/ubuntu-16.04-ucr-config.sh
@@ -427,6 +427,11 @@ Keywords=Network;Wireless;Wi-Fi;Wifi;LAN;AURI;Eduroam;Internet;Red" > /usr/share
 # Se activa el uso horario para que la fecha este siempre en hora tica
 sudo timedatectl set-timezone America/Costa_Rica
 
+# Complementos para LibreOffice
+wget https://www.languagetool.org/download/LanguageTool-stable.oxt
+sudo unopkg add LanguageTool-stable.oxt
+rm LanguageTool-stable.oxt
+
 # Firmador BCCR
 if [ "$arch" == 'x86' ]
 then


### PR DESCRIPTION
Se corrige el nombre del complento que se debe descargar, se aplica e cambio en las demás líneas que lo referencian y se agrega comentarios con la dirección del complemento para futuras actualizaciones.