### PR TITLE
Optimización de tiempos en GitlabCI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,8 +5,7 @@ image: ubuntu
 # SSH_SERVER: IP o nombre del servidor remoto
 # SSH_RPATH: Ruta remota donde se almacenara el artefacto
 before_script:
-  - apt-get update -qq && apt-get install -y -qq zip wget sudo rsync squashfs-tools xorriso
-  - 'which ssh-agent || ( apt-get update -y && apt-get install openssh-client -y )'
+  - apt-get update -qq && apt-get install -y -qq zip wget sudo rsync squashfs-tools xorriso openssh-client
   - eval $(ssh-agent -s)
   - ssh-add <(echo "$SSH_PRIVATE_KEY")
   
@@ -14,19 +13,29 @@ before_script:
   # WARNING: use only in docker container, if you use it with shell you will overwrite your user's ssh config
   - mkdir -p ~/.ssh
   - echo -e "Host *\n\tStrictHostKeyChecking no\n\n" > ~/.ssh/config
+after_script:
+  - eval $(ssh-agent -s)
+  - ssh-add <(echo "$SSH_PRIVATE_KEY")
+  - 'echo "$(pwd) - $SSH_USER@$SSH_SERVER:$SSH_RPATH"'
+  - 'scp $(find ubuntu-iso-customization/ -name *ucr*.iso) $SSH_USER@$SSH_SERVER:$SSH_RPATH'
+  - 'rm -r ubuntu-iso-customization/ '
+
+cache:
+  paths:
+  - cache/
+
 job_ubuntu:
-  script: 
-    - wget -O /tmp/ubuntu-16.04.3-desktop-amd64.iso http://espejos.ucr.ac.cr/ubuntu-cd/16.04/ubuntu-16.04.3-desktop-amd64.iso
-    - bash ./ubuntu-iso-customization.sh -d /tmp/ubuntu-16.04.3-desktop-amd64.iso
-    - 'echo $SSH_USER@$SSH_SERVER:$SSH_RPATH'
-    - 'scp $(find ./ -name *ucr*.iso) $SSH_USER@$SSH_SERVER:$SSH_RPATH'
+  script:
+    - mkdir -p cache/apt/ 
+    - test -f  cache/ubuntu-16.04.3-desktop-amd64.iso || wget -q -O cache/ubuntu-16.04.3-desktop-amd64.iso http://espejos.ucr.ac.cr/ubuntu-cd/16.04/ubuntu-16.04.3-desktop-amd64.iso
+    - bash ./ubuntu-iso-customization.sh -d -c cache/apt/ cache/ubuntu-16.04.3-desktop-amd64.iso
   only:
     - estable
+
 job_mate:
-  script: 
-    - wget -O /tmp/ubuntu-mate-16.04-desktop-amd64.iso http://cdimage.ubuntu.com/ubuntu-mate/releases/16.04/release/ubuntu-mate-16.04-desktop-amd64.iso
-    - bash ./ubuntu-iso-customization.sh -d /tmp/ubuntu-mate-16.04-desktop-amd64.iso
-    - 'echo $SSH_USER@$SSH_SERVER:$SSH_RPATH'
-    - 'scp $(find ./ -name *ucr*.iso) $SSH_USER@$SSH_SERVER:$SSH_RPATH'
+  script:
+    - mkdir -p cache/apt/
+    - test -f  cache/ubuntu-16.04.3-desktop-amd64.iso || wget -q -O cache/ubuntu-mate-16.04-desktop-amd64.iso http://cdimage.ubuntu.com/ubuntu-mate/releases/16.04/release/ubuntu-mate-16.04-desktop-amd64.iso
+    - bash ./ubuntu-iso-customization.sh -d -c cache/apt/ cache/ubuntu-mate-16.04-desktop-amd64.iso
   only:
     - estable

--- a/ubuntu-16.04-ucr-config.sh
+++ b/ubuntu-16.04-ucr-config.sh
@@ -41,14 +41,9 @@ do
  esac
 done
 
-if [ -z $1 ]; then
-  myhelp
-  exit 1
-fi
-
 # MENSAJE DE ADVERTENCIA
 # pregunta solo si el usuario no puso explicitamente la opcion -y
-if NOFORCE
+if $NOFORCE
 then
   echo ""
   echo "Este script podría sobreescribir la configuración actual, se recomienda ejecutarlo en una instalación limpia. Si este no es un sistema recién instalado o no ha realizado un respaldo, cancele la ejecución."

--- a/ubuntu-16.04-ucr-config.sh
+++ b/ubuntu-16.04-ucr-config.sh
@@ -12,9 +12,43 @@
 #
 # Github: https://github.com/cslucr/ubuntu-ucr
 
+# Mensaje de ayuda en el uso de la aplicación.
+function myhelp(){
+  echo "Modo de empleo: $0 <opciones>
+
+Opciones:
+
+  -y no cuestiona, fuerza la sobreescritura de configuraciones
+  -c directorio_cache Ruta absoluta al directorio donde se encuentra el cache de APT a utilizar
+  -h muestra esta ayuda
+
+Toma una instalación fresca de Ubuntu y la personaliza.";
+}
+
+# Captando parámetros
+# Is in development environment ?
+NOFORCE=true
+APT_CACHE=""
+
+while getopts c:hy option
+do
+ case "${option}"
+ in
+ y) NOFORCE=false;;
+ c) APT_CACHE=${OPTARG};;
+ h) myhelp
+    exit 0 ;;
+ esac
+done
+
+if [ -z $1 ]; then
+  myhelp
+  exit 1
+fi
+
 # MENSAJE DE ADVERTENCIA
 # pregunta solo si el usuario no puso explicitamente la opcion -y
-if [[ $1 != "-y" ]]
+if NOFORCE
 then
   echo ""
   echo "Este script podría sobreescribir la configuración actual, se recomienda ejecutarlo en una instalación limpia. Si este no es un sistema recién instalado o no ha realizado un respaldo, cancele la ejecución."
@@ -24,6 +58,12 @@ then
   then
     exit
   fi
+fi
+
+if [[ -d "$APT_CACHE" ]]; then
+  echo "Usando cache APT: $APT_CACHE"
+  APT_CACHE=$(readlink -f $APT_CACHE)
+  rsync -a --link-dest="${APT_CACHE}/" "${APT_CACHE}/" "/var/cache/apt/"
 fi
 
 # VARIABLES
@@ -241,6 +281,11 @@ sudo apt-get -y dist-upgrade
 sudo apt-get -y install $packages
 sudo apt-get -y purge $purgepackages
 sudo apt-get -y autoremove
+# Salva el cache de APT
+if [[ -d "$APT_CACHE" ]]; then
+  echo "Salvando cache APT: $APT_CACHE"
+  rsync -a --link-dest="${APT_CACHE}/" "/var/cache/apt/" "${APT_CACHE}/"
+fi
 sudo apt-get clean
 
 sudo rm /etc/apt/sources.list.d/sources-mirror-ucr.list # se elimina repositorio temporal

--- a/ubuntu-iso-customization.sh
+++ b/ubuntu-iso-customization.sh
@@ -74,7 +74,7 @@ if [ -z $ZIP ]; then
         echo "Modo Local (Desarrollo) activado"
         mkdir $CUSTOMIZATIONDIR/ubuntu-ucr-master/
         cp -ar $SCRIPTDIR/plymouth/ $SCRIPTDIR/gschema/ $SCRIPTDIR/*.list ubuntu-16.04-ucr-* $CUSTOMIZATIONDIR/ubuntu-ucr-master/
-        zip -r $CUSTOMIZATIONDIR/master.zip $CUSTOMIZATIONDIR/ubuntu-ucr-master
+        ( cd $CUSTOMIZATIONDIR; zip -r master.zip ubuntu-ucr-master; )
         rm -rf $CUSTOMIZATIONDIR/ubuntu-ucr-master/
     else
         wget -O $CUSTOMIZATIONDIR/master.zip https://github.com/cslucr/ubuntu-ucr/archive/master.zip
@@ -144,6 +144,7 @@ EOF
 if [[ -d "$APT_CACHE" ]]; then
   echo "Salvando cache APT: $APT_CACHE"
   rsync -a --link-dest="${APT_CACHE}/" "${EDIT}/apt/" "${APT_CACHE}/"
+  rm -r "${EDIT}/apt/"
 fi
 
 

--- a/ubuntu-iso-customization.sh
+++ b/ubuntu-iso-customization.sh
@@ -140,6 +140,13 @@ umount /dev/pts
 # Sale del directorio de edicion
 EOF
 
+# Actualiza cache de APT
+if [[ -d "$APT_CACHE" ]]; then
+  echo "Salvando cache APT: $APT_CACHE"
+  rsync -a --link-dest="${APT_CACHE}/" "${EDIT}/apt/" "${APT_CACHE}/"
+fi
+
+
 sudo umount $EDIT/dev
 sudo rm $EDIT/etc/resolv.conf $EDIT/etc/hosts
 sudo mv $EDIT/etc/resolv.conf.bak $EDIT/etc/resolv.conf

--- a/ubuntu-iso-customization.sh
+++ b/ubuntu-iso-customization.sh
@@ -11,6 +11,7 @@ Opciones:
 
   -d modo desarrollo, crea un zip apartir de la carpeta actual
   -z archivo.zip el archivo zip como repositorio
+  -c directorio_cache Ruta absoluta al directorio donde se encuentra el cache de APT a utilizar
   -h muestra esta ayuda
 
 Toma una imagen de Ubuntu, la personaliza de acuerdo al script de configuración y genera el archivo ISO personalizado para ser distribuido.";
@@ -20,13 +21,16 @@ Toma una imagen de Ubuntu, la personaliza de acuerdo al script de configuración
 # Is in development environment ?
 DEVELOPMENT=false
 ZIP=""
+APT_CACHE=""
+APT_CACHE_CHROOT=""
 
-while getopts z:hd option
+while getopts zc:hd option
 do
  case "${option}"
  in
  z) ZIP=${OPTARG};;
  d) DEVELOPMENT=true;;
+ c) APT_CACHE=${OPTARG};;
  h) myhelp
     exit 0 ;;
  esac
@@ -78,6 +82,11 @@ if [ -z $ZIP ]; then
 else
     cp $ZIP $CUSTOMIZATIONDIR/master.zip
 fi
+if [[ -d "$APT_CACHE" ]]; then
+  echo "Usando cache APT: $APT_CACHE"
+  APT_CACHE=$(readlink -f $APT_CACHE)
+fi
+
 
 echo "Se trabajará en el directorio $CUSTOMIZATIONDIR"
 cd $CUSTOMIZATIONDIR
@@ -92,6 +101,14 @@ sudo mv $CUSTOMIZATIONDIR/master.zip $EDIT/root
 sudo mv $EDIT/etc/resolv.conf $EDIT/etc/resolv.conf.bak
 sudo cp /etc/resolv.conf /etc/hosts $EDIT/etc/
 sudo mount --bind /dev/ $EDIT/dev/
+
+# Usa cache de APT
+if [[ -n "$APT_CACHE" ]]; then
+  mkdir -p $EDIT/apt/
+  rsync -a --link-dest="${APT_CACHE}/" "${APT_CACHE}/" "${EDIT}/apt/"
+  APT_CACHE_CHROOT=" -c '/apt/'"
+fi
+
 
 # Ejecuta ordenes dentro de directorio de edicion
 cat << EOF | sudo chroot $EDIT
@@ -109,7 +126,7 @@ cd ~
 # Descarga y ejecuta script de personalizacion ubuntu-ucr.
 # Puede omitir el script y en su lugar realizar una personalizacion manual
 unzip master.zip && rm master.zip
-bash ubuntu-ucr-master/ubuntu-16.04-ucr-config.sh -y
+bash ubuntu-ucr-master/ubuntu-16.04-ucr-config.sh -y $APT_CACHE_CHROOT
 rm -r ubuntu-ucr-master
 
 rm -rf /tmp/* ~/.bash_history


### PR DESCRIPTION
Fix #12 
Fix #20 

Utiliza cache para generar los ISOs nuevos y evitar descargar los ISOs maestros y toda la paquetería con cada compilación.
También corrige #20  para poder generar el ZIP cuando se usa el "modo desarrollo"