### PR TITLE
Elimina el autoarranque del servicio de firma digital del bccr

### DIFF
--- a/ubuntu-16.04-ucr-config.sh
+++ b/ubuntu-16.04-ucr-config.sh
@@ -536,7 +536,7 @@ else
 fi
 
 sudo dpkg -i $WGET_CACHE/firmador-bccr.deb || error_exit "Error al instalar firmador-bccr"
-
+sudo rm /etc/xdg/autostart/Firmador-BCCR.desktop
 
 if [ ! $WGET_CACHED ]; then
     rm $WGET_CACHE/sun_odf_template_pack_es.oxt


### PR DESCRIPTION
Soluciona el arranque del firmador del BCCR.  y soluciona el issue #38