### PR TITLE
Script para desarrollo 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+cache/
+ubuntu-iso-customization/
+ubuntu-mate-16.04.3-desktop-amd64.iso

--- a/dev_run.sh
+++ b/dev_run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+mkdir -p cache/apt
+mkdir -p cache/wget
+
+echo "Removing temporary file"
+sudo rm -rf ubuntu-iso-customization
+echo "Creating ISO"
+./ubuntu-iso-customization.sh -d -c "cache/apt" -w "cache/wget" ubuntu-mate-16.04.3-desktop-amd64.iso


### PR DESCRIPTION
Este script ayuda a correr el script utilizando cache y elimina antes ediciones anteriores del iso,  es muy útil pues ahorra varias horas de descarga si la conexión no es muy rápida. (la segunda vez que corre).
