### PR TITLE
Adds an option to get origin:suite format for unattended software

### DIFF
--- a/includes/unattended-upgrades.inc
+++ b/includes/unattended-upgrades.inc
@@ -10,54 +10,54 @@ APT_LIST_FOLDER=/var/lib/apt/lists
 
 # Uncomment unattended upgrades configuration.
 function enable_unattended_upgrades() {
-    [[ $(is_enabled_unattended_upgrades) == true ]] && return 0
-    replace_text $UNATTENDED_UPGRADES_FILE '//\t"${distro_id}:${distro_codename}-updates";' '\t"${distro_id}:${distro_codename}-updates";' true
-    replace_text $UNATTENDED_UPGRADES_FILE '//Unattended-Upgrade::MinimalSteps "false";' 'Unattended-Upgrade::MinimalSteps "true";' true
-    replace_text $UNATTENDED_UPGRADES_FILE '//Unattended-Upgrade::Remove-Unused-Dependencies "false";' 'Unattended-Upgrade::Remove-Unused-Dependencies "true";' true
-    return 0
+  [[ $(is_enabled_unattended_upgrades) == true ]] && return 0
+  replace_text $UNATTENDED_UPGRADES_FILE '//\t"${distro_id}:${distro_codename}-updates";' '\t"${distro_id}:${distro_codename}-updates";' true
+  replace_text $UNATTENDED_UPGRADES_FILE '//Unattended-Upgrade::MinimalSteps "false";' 'Unattended-Upgrade::MinimalSteps "true";' true
+  replace_text $UNATTENDED_UPGRADES_FILE '//Unattended-Upgrade::Remove-Unused-Dependencies "false";' 'Unattended-Upgrade::Remove-Unused-Dependencies "true";' true
+  return 0
 }
 
 # Comment unattended upgrades configuration.
 function disable_unattended_upgrades() {
-    [[ $(is_enabled_unattended_upgrades) == false ]] && return 0
-    replace_text $UNATTENDED_UPGRADES_FILE '\t"${distro_id}:${distro_codename}-updates";' '//\t"${distro_id}:${distro_codename}-updates";' true
-    replace_text $UNATTENDED_UPGRADES_FILE 'Unattended-Upgrade::MinimalSteps "false";' '//Unattended-Upgrade::MinimalSteps "false";' true
-    replace_text $UNATTENDED_UPGRADES_FILE 'Unattended-Upgrade::Remove-Unused-Dependencies "false";' '//Unattended-Upgrade::Remove-Unused-Dependencies "false";' true
-    return 0
+  [[ $(is_enabled_unattended_upgrades) == false ]] && return 0
+  replace_text $UNATTENDED_UPGRADES_FILE '\t"${distro_id}:${distro_codename}-updates";' '//\t"${distro_id}:${distro_codename}-updates";' true
+  replace_text $UNATTENDED_UPGRADES_FILE 'Unattended-Upgrade::MinimalSteps "false";' '//Unattended-Upgrade::MinimalSteps "false";' true
+  replace_text $UNATTENDED_UPGRADES_FILE 'Unattended-Upgrade::Remove-Unused-Dependencies "false";' '//Unattended-Upgrade::Remove-Unused-Dependencies "false";' true
+  return 0
 }
 
 # Determines if the unattended upgrades are enabled or not.
 function is_enabled_unattended_upgrades() {
-    local result=$(grep '"${distro_id}:${distro_codename}-updates";' $UNATTENDED_UPGRADES_FILE)
-    ! [[ $result == *'//'* ]] && echo true && return 0
-    echo false && return 0
+  local result=$(grep '"${distro_id}:${distro_codename}-updates";' $UNATTENDED_UPGRADES_FILE)
+  ! [[ $result == *'//'* ]] && echo true && return 0
+  echo false && return 0
 }
 
 # Add a new unattended upgrade if is not already added.
 function add_unattended_upgrade() {
-    local unattended_software=$( get_unattended_software_name "$1" "$2")
-    
-    # Verify software name was passed.
-    [[ -z "$unattended_software" ]] && return 1
+  local unattended_software=$( get_unattended_software_name "$1" "$2")
+  
+  # Verify software name was passed.
+  [[ -z "$unattended_software" ]] && return 1
 
-    # Verify if the upgrade is already added.
-    [[ $(file_contains_string $UNATTENDED_UPGRADES_FILE $unattended_software) == true ]] && return 0
+  # Verify if the upgrade is already added.
+  [[ $(file_contains_string $UNATTENDED_UPGRADES_FILE $unattended_software) == true ]] && return 0
 
-    replace_text $UNATTENDED_UPGRADES_FILE 'Unattended-Upgrade::Allowed-Origins {' 'Unattended-Upgrade::Allowed-Origins {\n\t"UNATTENDED_SOFTWARE_PLACEHOLDER";' true
-    replace_text $UNATTENDED_UPGRADES_FILE 'UNATTENDED_SOFTWARE_PLACEHOLDER' "$unattended_software" true
-    
-    return 0
+  replace_text $UNATTENDED_UPGRADES_FILE 'Unattended-Upgrade::Allowed-Origins {' 'Unattended-Upgrade::Allowed-Origins {\n\t"UNATTENDED_SOFTWARE_PLACEHOLDER";' true
+  replace_text $UNATTENDED_UPGRADES_FILE 'UNATTENDED_SOFTWARE_PLACEHOLDER' "$unattended_software" true
+  
+  return 0
 }
 
 # Remove an unattended upgrade.
 function remove_unattended_upgrade() {
-    local unattended_software=$( get_unattended_software_name "$1" "$2")
+  local unattended_software=$( get_unattended_software_name "$1" "$2")
 
-    # Verify software name was passed.
-    [[ -z "$unattended_software" ]] && return 1
+  # Verify software name was passed.
+  [[ -z "$unattended_software" ]] && return 1
 
-    replace_text $UNATTENDED_UPGRADES_FILE "$unattended_software" 'UNATTENDED_SOFTWARE_PLACEHOLDER' true
-    replace_text $UNATTENDED_UPGRADES_FILE '\t"LP-PPA-UNATTENDED_SOFTWARE_PLACEHOLDER:${distro_codename}";' '' true
+  replace_text $UNATTENDED_UPGRADES_FILE "$unattended_software" 'UNATTENDED_SOFTWARE_PLACEHOLDER' true
+  replace_text $UNATTENDED_UPGRADES_FILE '\t"LP-PPA-UNATTENDED_SOFTWARE_PLACEHOLDER:${distro_codename}";' '' true
 }
 
 # Get origin:suite format for unattended software based on repo name

--- a/includes/unattended-upgrades.inc
+++ b/includes/unattended-upgrades.inc
@@ -2,7 +2,7 @@
 #
 # Handle unattended-upgrades configuration.
 
-source ./includes/configuration.sh
+source ./includes/configuration.inc
 
 # Path to unattended updates file
 UNATTENDED_UPGRADES_FILE=/etc/apt/apt.conf.d/50unattended-upgrades
@@ -61,6 +61,7 @@ function remove_unattended_upgrade() {
 
 # Get origin:suite format for unattended software based on repo name
 function get_unattended_software_name() {
+  local http_regex='https?://([-A-Za-z0-9\+&@#/%?=~_|!:,.;]*[-A-Za-z0-9\+&@#/%=~_|])'
   local repo_type=$1
   local repo_name=$2
 
@@ -71,7 +72,7 @@ function get_unattended_software_name() {
   # Generates repo name for apt policy data
   case "$repo_type" in
     apt)
-      repo_name=$( [[ "$repo_name" =~ http[s]?://(.*+)[[:space:]].+[[:space:]].+ ]] && echo ${BASH_REMATCH[1]} | sed 's:/*$::' )
+      repo_name=$( [[ "$repo_name" =~ $http_regex ]] && echo ${BASH_REMATCH[1]} | sed 's:/*$::' )
       ;;
     ppa)
       ;;

--- a/includes/unattended-upgrades.inc
+++ b/includes/unattended-upgrades.inc
@@ -6,6 +6,7 @@ source ./includes/configuration.sh
 
 # Path to unattended updates file
 UNATTENDED_UPGRADES_FILE=/etc/apt/apt.conf.d/50unattended-upgrades
+APT_LIST_FOLDER=/var/lib/apt/lists
 
 # Uncomment unattended upgrades configuration.
 function enable_unattended_upgrades() {
@@ -34,15 +35,15 @@ function is_enabled_unattended_upgrades() {
 
 # Add a new unattended upgrade if is not already added.
 function add_unattended_upgrade() {
-    local unattended_software=$1
-
+    local unattended_software=$( get_unattended_software_name "$1" "$2")
+    
     # Verify software name was passed.
     [[ -z "$unattended_software" ]] && return 1
 
     # Verify if the upgrade is already added.
     [[ $(file_contains_string $UNATTENDED_UPGRADES_FILE $unattended_software) == true ]] && return 0
 
-    replace_text $UNATTENDED_UPGRADES_FILE 'Unattended-Upgrade::Allowed-Origins {' 'Unattended-Upgrade::Allowed-Origins {\n\t"LP-PPA-UNATTENDED_SOFTWARE_PLACEHOLDER:${distro_codename}";' true
+    replace_text $UNATTENDED_UPGRADES_FILE 'Unattended-Upgrade::Allowed-Origins {' 'Unattended-Upgrade::Allowed-Origins {\n\t"UNATTENDED_SOFTWARE_PLACEHOLDER";' true
     replace_text $UNATTENDED_UPGRADES_FILE 'UNATTENDED_SOFTWARE_PLACEHOLDER' "$unattended_software" true
     
     return 0
@@ -50,12 +51,39 @@ function add_unattended_upgrade() {
 
 # Remove an unattended upgrade.
 function remove_unattended_upgrade() {
-    local unattended_software=$1
+    local unattended_software=$( get_unattended_software_name "$1" "$2")
 
     # Verify software name was passed.
     [[ -z "$unattended_software" ]] && return 1
 
     replace_text $UNATTENDED_UPGRADES_FILE "$unattended_software" 'UNATTENDED_SOFTWARE_PLACEHOLDER' true
     replace_text $UNATTENDED_UPGRADES_FILE '\t"LP-PPA-UNATTENDED_SOFTWARE_PLACEHOLDER:${distro_codename}";' '' true
+}
+
+# Get origin:suite format for unattended software based on repo name
+function get_unattended_software_name() {
+  local repo_type=$1
+  local repo_name=$2
+
+  # Verify repository type and name.
+  [[ -z "$repo_type" ]] && echo '' && return 1
+  [[ -z "$repo_name" ]] && echo '' && return 1
+   
+  # Generates repo name for apt policy data
+  case "$repo_type" in
+    apt)
+      repo_name=$( [[ "$repo_name" =~ http[s]?://(.*+)[[:space:]].+[[:space:]].+ ]] && echo ${BASH_REMATCH[1]} | sed 's:/*$::' )
+      echo "###### $repo_name"
+      ;;
+    ppa)
+      ;;
+    *)
+      echo '' && return 1
+  esac
+  echo "###### $repo_name"
+  local repo_release_info=$( apt-cache policy | grep -A 2 "$repo_name" | head -n 3 )
+  [[ -z "$repo_release_info" ]] && echo '' && return 1
+  
+  [[ "$repo_release_info" =~ o=(.*),a=(.*),n= ]] && echo ${BASH_REMATCH[1]}:${BASH_REMATCH[2]}
 }
 

--- a/includes/unattended-upgrades.inc
+++ b/includes/unattended-upgrades.inc
@@ -9,7 +9,7 @@ UNATTENDED_UPGRADES_FILE=/etc/apt/apt.conf.d/50unattended-upgrades
 
 # Uncomment unattended upgrades configuration.
 function enable_unattended_upgrades() {
-    [[ $(enabled_unattended_upgrades) == true ]] && return 0
+    [[ $(is_enabled_unattended_upgrades) == true ]] && return 0
     replace_text $UNATTENDED_UPGRADES_FILE '//\t"${distro_id}:${distro_codename}-updates";' '\t"${distro_id}:${distro_codename}-updates";' true
     replace_text $UNATTENDED_UPGRADES_FILE '//Unattended-Upgrade::MinimalSteps "false";' 'Unattended-Upgrade::MinimalSteps "true";' true
     replace_text $UNATTENDED_UPGRADES_FILE '//Unattended-Upgrade::Remove-Unused-Dependencies "false";' 'Unattended-Upgrade::Remove-Unused-Dependencies "true";' true
@@ -18,7 +18,7 @@ function enable_unattended_upgrades() {
 
 # Comment unattended upgrades configuration.
 function disable_unattended_upgrades() {
-    [[ $(enabled_unattended_upgrades) == false ]] && return 0
+    [[ $(is_enabled_unattended_upgrades) == false ]] && return 0
     replace_text $UNATTENDED_UPGRADES_FILE '\t"${distro_id}:${distro_codename}-updates";' '//\t"${distro_id}:${distro_codename}-updates";' true
     replace_text $UNATTENDED_UPGRADES_FILE 'Unattended-Upgrade::MinimalSteps "false";' '//Unattended-Upgrade::MinimalSteps "false";' true
     replace_text $UNATTENDED_UPGRADES_FILE 'Unattended-Upgrade::Remove-Unused-Dependencies "false";' '//Unattended-Upgrade::Remove-Unused-Dependencies "false";' true
@@ -26,7 +26,7 @@ function disable_unattended_upgrades() {
 }
 
 # Determines if the unattended upgrades are enabled or not.
-function enabled_unattended_upgrades() {
+function is_enabled_unattended_upgrades() {
     result=$(grep '"${distro_id}:${distro_codename}-updates";' $UNATTENDED_UPGRADES_FILE)
     ! [[ $result == *'//'* ]] && echo true && return 0
     echo false && return 0

--- a/includes/unattended-upgrades.inc
+++ b/includes/unattended-upgrades.inc
@@ -6,7 +6,6 @@ source ./includes/configuration.sh
 
 # Path to unattended updates file
 UNATTENDED_UPGRADES_FILE=/etc/apt/apt.conf.d/50unattended-upgrades
-APT_LIST_FOLDER=/var/lib/apt/lists
 
 # Uncomment unattended upgrades configuration.
 function enable_unattended_upgrades() {
@@ -73,14 +72,14 @@ function get_unattended_software_name() {
   case "$repo_type" in
     apt)
       repo_name=$( [[ "$repo_name" =~ http[s]?://(.*+)[[:space:]].+[[:space:]].+ ]] && echo ${BASH_REMATCH[1]} | sed 's:/*$::' )
-      echo "###### $repo_name"
       ;;
     ppa)
       ;;
     *)
       echo '' && return 1
   esac
-  echo "###### $repo_name"
+  
+  #Get repo info from apt policy
   local repo_release_info=$( apt-cache policy | grep -A 2 "$repo_name" | head -n 3 )
   [[ -z "$repo_release_info" ]] && echo '' && return 1
   

--- a/includes/unattended-upgrades.inc
+++ b/includes/unattended-upgrades.inc
@@ -27,14 +27,14 @@ function disable_unattended_upgrades() {
 
 # Determines if the unattended upgrades are enabled or not.
 function is_enabled_unattended_upgrades() {
-    result=$(grep '"${distro_id}:${distro_codename}-updates";' $UNATTENDED_UPGRADES_FILE)
+    local result=$(grep '"${distro_id}:${distro_codename}-updates";' $UNATTENDED_UPGRADES_FILE)
     ! [[ $result == *'//'* ]] && echo true && return 0
     echo false && return 0
 }
 
 # Add a new unattended upgrade if is not already added.
 function add_unattended_upgrade() {
-    unattended_software=$1
+    local unattended_software=$1
 
     # Verify software name was passed.
     [[ -z "$unattended_software" ]] && return 1
@@ -50,7 +50,7 @@ function add_unattended_upgrade() {
 
 # Remove an unattended upgrade.
 function remove_unattended_upgrade() {
-    unattended_software=$1
+    local unattended_software=$1
 
     # Verify software name was passed.
     [[ -z "$unattended_software" ]] && return 1

--- a/test/unattended-upgrades.bats
+++ b/test/unattended-upgrades.bats
@@ -2,7 +2,7 @@
 #
 # Unattended updates script tests.
 
-source ./includes/unattended-upgrades.sh
+source ./includes/unattended-upgrades.inc
 
 @test "Enable unattended upgrades" {
     run enable_unattended_upgrades
@@ -11,7 +11,7 @@ source ./includes/unattended-upgrades.sh
 }
 
 @test "Verify unattended upgrades enabled" {
-    run enabled_unattended_upgrades
+    run is_enabled_unattended_upgrades
     [[ $output == true ]]
 }
 
@@ -22,7 +22,7 @@ source ./includes/unattended-upgrades.sh
 }
 
 @test "Verify unattended upgrades disabled" {
-    run enabled_unattended_upgrades
+    run is_enabled_unattended_upgrades
     [[ $output == false ]]
 }
 
@@ -32,9 +32,8 @@ source ./includes/unattended-upgrades.sh
 }
 
 @test "Add unattended upgrade" {
-    run add_unattended_upgrade 'libreoffice-libreoffice-6-0'
-    run file_contains_string $UNATTENDED_UPGRADES_FILE 'libreoffice-libreoffice-6-0'
-    [[ $output == true ]]
+    run add_unattended_upgrade 'apt' "$( cat /etc/apt/sources.list | grep '^deb ' | head -n 1 )"
+    [[ $status -eq 0 ]]
 }
 
 @test "Remove unattended upgrade: exit without software name" {
@@ -43,8 +42,7 @@ source ./includes/unattended-upgrades.sh
 }
 
 @test "Remove unattended upgrade" {
-    run remove_unattended_upgrade 'libreoffice-libreoffice-6-0'
-    run file_contains_string $UNATTENDED_UPGRADES_FILE 'libreoffice-libreoffice-6-0'
-    [[ $output == false ]]
+    run remove_unattended_upgrade 'apt' "$( cat /etc/apt/sources.list | grep '^deb ' | head -n 1 )"
+    [[ $status -eq 0 ]]
 }
 


### PR DESCRIPTION
Using apt-get policy, the function get_unattended_software_name provides the "origin:suite" string to be placed in the unattended software file

`function get_unattended_software_name()` requieres 2 params: 

- repo_type: apt | ppa
- repo_name: String with the apt repo or ppa repo