### PR TITLE
Fixes source of .sh files which are now .inc.

### DIFF
--- a/includes/parameters.inc
+++ b/includes/parameters.inc
@@ -2,8 +2,8 @@
 #
 # Handle scripts parameters.
 
-source ./includes/messages.sh
-source ./includes/vars.sh
+source ./includes/messages.inc
+source ./includes/vars.inc
 
 # Capture parameters.
 function get_parameters() {

--- a/test/configuration.bats
+++ b/test/configuration.bats
@@ -2,7 +2,7 @@
 #
 # Configuration script tests.
 
-source ./includes/configuration.sh
+source ./includes/configuration.inc
 
 @test "Replace text: exit with unexisting file path" {
     run replace_text $HOME/myUnexistingFileToModify

--- a/test/messages.bats
+++ b/test/messages.bats
@@ -2,7 +2,7 @@
 #
 # Messages script tests.
 
-source ./includes/messages.sh
+source ./includes/messages.inc
 
 @test "Show help" {
     [[ $(help) == *'Customizes an Ubuntu installation'* ]]

--- a/test/parameters.bats
+++ b/test/parameters.bats
@@ -2,8 +2,8 @@
 #
 # Parameters script tests.
 
-source ./includes/parameters.sh
-source ./includes/vars.sh
+source ./includes/parameters.inc
+source ./includes/vars.inc
 
 @test "Get APT_CACHE parameter" {
     get_parameters -c -y

--- a/ubuntu-ucr-customization.sh
+++ b/ubuntu-ucr-customization.sh
@@ -14,10 +14,10 @@
 #
 # Github: https://github.com/cslucr/ubuntu-ucr
 
-source includes/messages.sh
-source includes/parameters.sh
-source includes/unattended-upgrades.sh
-source includes/vars.sh
+source includes/messages.inc
+source includes/parameters.inc
+source includes/unattended-upgrades.inc
+source includes/vars.inc
 
 # Handle parameters
 get_parameters "$@"


### PR DESCRIPTION
From  9563da5  include/\*.sh were renamed to include/*.inc but source commands were not updated. This PR fixes it.

Doesn't touch unattended because #73 already fixes it.
